### PR TITLE
Updated pouchdb to version 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lodash.defaults": "3.1.2",
     "lodash.uniq": "3.2.2",
     "path": "0.11.14",
-    "pouchdb": "4.0.3",
+    "pouchdb": "5.0.0",
     "pouchdb-find": "0.4.0",
     "url": "0.10.3"
   }


### PR DESCRIPTION
:rocket:

pouchdb just published version 5.0.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 54 commits (ahead by 54, behind by 6).

- [cbc2543](https://github.com/pouchdb/pouchdb/commit/cbc2543ed28955f7c2bba8c1a4d5fbdf3febaff2): (#4412) - pouchdb 5.0.0 blog post
- [25da9e5](https://github.com/pouchdb/pouchdb/commit/25da9e52a34b20f92cb871d410affd94d717670f): (#4329) - clean up docs, add fruitdown safari test
- [a0fc6a9](https://github.com/pouchdb/pouchdb/commit/a0fc6a972a3332b91877f5f5c23efad903b7dc84): (#4329) - Add fruitdown as a supported adapter
- [2457a2b](https://github.com/pouchdb/pouchdb/commit/2457a2b2d91d080a18ec10720fd6531cd6db3b08): (#4402) - fix Firefox FileReader in a WW
- [87c60b6](https://github.com/pouchdb/pouchdb/commit/87c60b69d09cac0cbaf3f3b7af4e5080a2995c53): (#4414) - chore(package): update istanbul to version 0.3.22
- [3cc683c](https://github.com/pouchdb/pouchdb/commit/3cc683c916415b6fc2749b4fd41914d36105e1c4): (#4407) - chore(package): update replace to version 0.3.0
- [6c20bc9](https://github.com/pouchdb/pouchdb/commit/6c20bc9adc65c79cb4ad9b407addedf1b978e7e2): (#4406) - chore(package): update express-pouchdb to version 0.17.3
- [db6eadc](https://github.com/pouchdb/pouchdb/commit/db6eadc3dee6109381319a829955fc8d3137c107): (#2982) - Add heartbeat to keep alive long connections
- [31cdcf8](https://github.com/pouchdb/pouchdb/commit/31cdcf8993924414d13f0d3df080d60220ba2b87): (#4276) - Maintain cancelled state in replicator better
- [be3366a](https://github.com/pouchdb/pouchdb/commit/be3366ab379d23801d9b9164f84bad28629b06cd): (#4401) - chore(package): update watchify to version 3.4.0
- [e099d05](https://github.com/pouchdb/pouchdb/commit/e099d05f93034dd6980e85d2771df2473bbed349): (#4399) - chore(package): update commander to version 2.8.1
- [f7280a7](https://github.com/pouchdb/pouchdb/commit/f7280a792ff73a76cd7145166326dd0feb0bde78): (#4397) - chore(package): update wd to version 0.3.12
- [eb1ff86](https://github.com/pouchdb/pouchdb/commit/eb1ff8631d03a91404209ddc4eaeed7d4ac285e2): (#4395) - Clarify the merge procedure
- [e50326f](https://github.com/pouchdb/pouchdb/commit/e50326f306f85f85d900ed0da28557f7fb407956): (#4393) - allow custom map/reduce implementations
- [567e395](https://github.com/pouchdb/pouchdb/commit/567e395d6a4213d29e420e46669fb924dac26c23): (#4932) - chore(package): update chai to version 3.3.0


There are 54 commits in total. See the [full diff](https://github.com/pouchdb/pouchdb/compare/e3b6323a2e3912e03bdee9c0fd68c3a8d267c91a...cbc2543ed28955f7c2bba8c1a4d5fbdf3febaff2).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>