### PR TITLE
Updated testem to version 0.9.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "browserify": "11.2.0",
     "tape": "4.2.0",
-    "testem": "0.9.5"
+    "testem": "0.9.7"
   },
   "dependencies": {
     "lodash.assign": "3.2.0",


### PR DESCRIPTION
:rocket:

testem just published version 0.9.7, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 8 commits (ahead by 8, behind by 0).

- [c71081d](https://github.com/airportyh/testem/commit/c71081dfb187d784a86a193b66354c14d5784c1f): 0.9.7
- [7cf6e33](https://github.com/airportyh/testem/commit/7cf6e330eba1713df44664e3b143fff4da512772): Merge pull request #644 from asakusuma/query-param-config
- [516aa82](https://github.com/airportyh/testem/commit/516aa82ed651bb2bd9da1c6de05013d5ce19ecf7): Add query_params config
- [18ef335](https://github.com/airportyh/testem/commit/18ef3355dd533742eac68bd0e6dcf766b5d1462d): 0.9.6
- [e6b363d](https://github.com/airportyh/testem/commit/e6b363d52105e759261e531971de88744b685794): Merge pull request #643 from asakusuma/config-path
- [3a2b899](https://github.com/airportyh/testem/commit/3a2b899be999533346b4b4268269551858f4dbe7): Allow custom path for config directory
- [8beb615](https://github.com/airportyh/testem/commit/8beb615eeea8a718d6390c0e9ac9eef01957df81): Merge pull request #641 from johanneswuerbach/socket-137
- [60bcdbb](https://github.com/airportyh/testem/commit/60bcdbb8c52eaf0991e22d44816a0be094c7438c): socket.io v1.3.7

See the [full diff](https://github.com/airportyh/testem/compare/ab885947875f81748c9de1b7767bc18f4939d298...c71081dfb187d784a86a193b66354c14d5784c1f).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>